### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Date.php
+++ b/lib/Horde/Date.php
@@ -555,7 +555,7 @@ class Horde_Date
     public function toDateTime()
     {
         try {
-            $date = new DateTime(null, new DateTimeZone($this->_timezone));
+            $date = new DateTime("", new DateTimeZone($this->_timezone));
             $date->setDate($this->_year, $this->_month, $this->_mday);
             $date->setTime($this->_hour, $this->_min, $this->_sec);
         } catch (Exception $e) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Date/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Date/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Date Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Date/DateTest.php
+++ b/test/Horde/Date/DateTest.php
@@ -10,15 +10,15 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_DateTest extends PHPUnit_Framework_TestCase
+class Horde_Date_DateTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->_oldTimezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Berlin');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->_oldTimezone);
     }

--- a/test/Horde/Date/RecurrenceTest.php
+++ b/test/Horde/Date/RecurrenceTest.php
@@ -12,14 +12,14 @@
  */
 class Horde_Date_RecurrenceTest extends Horde_Test_Case
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->ical = new Horde_Icalendar();
         $this->_oldTimezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Berlin');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->_oldTimezone);
     }

--- a/test/Horde/Date/Repeater/DayNameTest.php
+++ b/test/Horde/Date/Repeater/DayNameTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_DayNameTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_DayNameTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/Repeater/DayTest.php
+++ b/test/Horde/Date/Repeater/DayTest.php
@@ -10,7 +10,7 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_DayTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_DayTest extends Horde_Test_Case
 {
     public function testNextFuture()
     {

--- a/test/Horde/Date/Repeater/HourTest.php
+++ b/test/Horde/Date/Repeater/HourTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_HourTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_HourTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/Repeater/MonthNameTest.php
+++ b/test/Horde/Date/Repeater/MonthNameTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_MonthNameTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_MonthNameTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/Repeater/MonthTest.php
+++ b/test/Horde/Date/Repeater/MonthTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_MonthTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_MonthTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/Repeater/TimeTest.php
+++ b/test/Horde/Date/Repeater/TimeTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_TimeTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_TimeTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/Repeater/WeekTest.php
+++ b/test/Horde/Date/Repeater/WeekTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_WeekTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_WeekTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/Repeater/WeekendTest.php
+++ b/test/Horde/Date/Repeater/WeekendTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_WeekendTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_WeekendTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/Repeater/YearTest.php
+++ b/test/Horde/Date/Repeater/YearTest.php
@@ -10,9 +10,9 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_Repeater_YearTest extends PHPUnit_Framework_TestCase
+class Horde_Date_Repeater_YearTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->now = new Horde_Date('2006-08-16 14:00:00');
     }

--- a/test/Horde/Date/SpanTest.php
+++ b/test/Horde/Date/SpanTest.php
@@ -10,7 +10,7 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_SpanTest extends PHPUnit_Framework_TestCase
+class Horde_Date_SpanTest extends Horde_Test_Case
 {
     public function testWidth()
     {

--- a/test/Horde/Date/UtilsTest.php
+++ b/test/Horde/Date/UtilsTest.php
@@ -10,7 +10,7 @@
  * @package    Date
  * @subpackage UnitTests
  */
-class Horde_Date_UtilsTest extends PHPUnit_Framework_TestCase
+class Horde_Date_UtilsTest extends Horde_Test_Case
 {
     public function testFirstDayOfWeek()
     {


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-date/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: 1011_php8.1.patch Undo DateTime::format changes. Not doable. https://salsa.debian.org/horde-team/php-horde-date/-/blob/debian-sid/debian/patches/1011_php8.1.patch
