### PR TITLE
fix setlocale to provide proper type

### DIFF
--- a/lib/Horde/Date.php
+++ b/lib/Horde/Date.php
@@ -1364,7 +1364,7 @@ class Horde_Date implements DateInterface
 
         // Use stored timezone and locale
         $timezone = $this->_timezone ?? date_default_timezone_get();
-        $locale = $locale ?? $this->_locale ?? setlocale(LC_ALL, 0) ?: 'en_US';
+        $locale = $locale ?? $this->_locale ?? setlocale(LC_ALL, '0') ?: 'en_US';
 
         return $formatter->format($this, $pattern, $locale, $timezone);
     }

--- a/test/Unit/FormatTest.php
+++ b/test/Unit/FormatTest.php
@@ -520,7 +520,7 @@ class FormatTest extends TestCase
         $timestamp = strtotime('2026-03-17 14:30:00');
 
         // Try to set Arabic locale - skip if not available
-        $oldLocale = setlocale(LC_ALL, 0);
+        $oldLocale = setlocale(LC_ALL, '0');
         if (!setlocale(LC_ALL, 'ar_SA.UTF-8')) {
             $this->markTestSkipped('ar_SA.UTF-8 locale not available.');
         }
@@ -556,7 +556,7 @@ class FormatTest extends TestCase
         $timestamp = strtotime('2026-03-17 14:30:00');
 
         // Try to set Hebrew locale - skip if not available
-        $oldLocale = setlocale(LC_ALL, 0);
+        $oldLocale = setlocale(LC_ALL, '0');
         if (!setlocale(LC_ALL, 'he_IL.UTF-8')) {
             $this->markTestSkipped('he_IL.UTF-8 locale not available.');
         }

--- a/test/Unnamespaced/DateFormatTest.php
+++ b/test/Unnamespaced/DateFormatTest.php
@@ -35,7 +35,7 @@ class DateFormatTest extends TestCase
         date_default_timezone_set('UTC');
 
         // Save current locale
-        $this->oldLocale = setlocale(LC_ALL, 0);
+        $this->oldLocale = setlocale(LC_ALL, '0');
 
         // Set a known locale for consistent test results
         setlocale(LC_ALL, 'en_US.UTF-8');

--- a/test/Unnamespaced/DatePluggableFormatterTest.php
+++ b/test/Unnamespaced/DatePluggableFormatterTest.php
@@ -37,7 +37,7 @@ class DatePluggableFormatterTest extends TestCase
         date_default_timezone_set('UTC');
 
         // Save current locale
-        $this->oldLocale = setlocale(LC_ALL, 0);
+        $this->oldLocale = setlocale(LC_ALL, '0');
 
         // Set a known locale for consistent test results
         setlocale(LC_ALL, 'en_US.UTF-8');


### PR DESCRIPTION
This will fix setlocale to provide the proper type.

Changed: $locale = setlocale(LC_ALL, 0);
to: $locale = setlocale(LC_ALL, '0');

will change it to null if preferred.

Going to do this for horde/date, horde/util, horde/autoloader as well.

@ralflang , @TDannhauer