### PR TITLE
Cast dayMask to int in recurOnDay methods

### DIFF
--- a/lib/Horde/Date/Recurrence.php
+++ b/lib/Horde/Date/Recurrence.php
@@ -177,12 +177,12 @@ class Horde_Date_Recurrence
 
     public function recurOnDay($dayMask)
     {
-        return ($this->modern->getDayMask() & $dayMask);
+        return ($this->modern->getDayMask() & (int) $dayMask);
     }
 
     public function setRecurOnDay($dayMask)
     {
-        $this->modern->setDayMask($dayMask);
+        $this->modern->setDayMask((int) $dayMask);
     }
 
     public function getRecurOnDays()


### PR DESCRIPTION
Summary
Fix a TypeError when ActiveSync imports recurring calendar events into Kronolith.

WBXML decoding stores numeric recurrence fields (e.g. dayofweek) as strings. Horde\Date\Recurrence\Recurrence::setDayMask() requires an int, so Horde_Date_Recurrence::setRecurOnDay() fails when called from Horde_ActiveSync_Message_Appointment::getRecurrence().

Cast the day mask to int in setRecurOnDay() and recurOnDay(), matching how setRecurInterval() and setRecurCount() already normalize values before passing them to the modern recurrence implementation.