### PR TITLE
Fix/php vs icu format

### DIFF
--- a/src/Format.php
+++ b/src/Format.php
@@ -19,7 +19,6 @@ namespace Horde\Date;
 
 use DateTime;
 use DateTimeInterface;
-use Horde\Date\Formatter\DateTimeFormatter;
 use Horde\Date\Formatter\IcuFormatter;
 use IntlDateFormatter;
 use InvalidArgumentException;
@@ -310,11 +309,14 @@ class Format
     /**
      * Parse a formatted date string to a DateInterface object
      *
-     * Detects the pattern type (strftime, ICU, or PHP date()) and dispatches
-     * to the appropriate formatter's parse method.
+     * Auto-detects strftime patterns (containing %) and converts them to ICU.
+     * All other patterns are treated as ICU (including shortcuts like short,
+     * medium, long, full).
+     *
+     * For PHP date() patterns, use DateTimeFormatter::parse() directly.
      *
      * @param string $formattedString  The date string to parse
-     * @param string $pattern  Format pattern (strftime, ICU, or PHP date() syntax)
+     * @param string $pattern  Format pattern (strftime or ICU syntax)
      * @param string|Stringable $locale  Locale for parsing (default: 'en_US')
      * @param string|null $timezone  Timezone identifier (null = UTC)
      *
@@ -336,12 +338,6 @@ class Format
             return $formatter->parse($formattedString, $icuPattern, $locale, $timezone);
         }
 
-        if (self::isPhpDateFormat($pattern)) {
-            $formatter = new DateTimeFormatter();
-            return $formatter->parse($formattedString, $pattern, $locale, $timezone);
-        }
-
-        // Default: treat as ICU pattern
         $formatter = new IcuFormatter();
         return $formatter->parse($formattedString, $pattern, $locale, $timezone);
     }
@@ -353,9 +349,13 @@ class Format
      * the string atomically. This avoids regex-based string splitting which
      * breaks with AM/PM markers and other multi-word tokens.
      *
+     * PHP date() patterns are not auto-detected due to ambiguity with ICU
+     * single-letter patterns. Use DateTimeFormatter::parse() directly for
+     * PHP date() syntax.
+     *
      * @param string $formattedString  The date+time string to parse
-     * @param string $datePattern  Date format pattern (strftime, ICU, or PHP date())
-     * @param string $timePattern  Time format pattern (strftime, ICU, or PHP date())
+     * @param string $datePattern  Date format pattern (strftime or ICU)
+     * @param string $timePattern  Time format pattern (strftime or ICU)
      * @param string|Stringable $locale  Locale for parsing (default: 'en_US')
      * @param string|null $timezone  Timezone identifier (null = UTC)
      *
@@ -386,43 +386,6 @@ class Format
 
         $formatter = new IcuFormatter();
         return $formatter->parse($formattedString, $combinedPattern, $locale, $timezone);
-    }
-
-    /**
-     * Detect if a pattern uses PHP date() syntax (single letters like Y, m, d, H, i, s)
-     *
-     * Distinguishes from ICU patterns which use repeated letters (yyyy, MM, dd).
-     * A pattern is considered PHP date() if it contains characteristic PHP date
-     * letters that do not appear in ICU patterns as single characters.
-     *
-     * @param string $pattern  Pattern to check
-     * @return bool  True if the pattern appears to be PHP date() syntax
-     */
-    public static function isPhpDateFormat(string $pattern): bool
-    {
-        // ICU locale shortcuts (handled by IcuFormatter, not PHP date())
-        if (in_array($pattern, ['short', 'medium', 'long', 'full'], true)) {
-            return false;
-        }
-
-        // These characters are unique to PHP date() and don't appear as single
-        // letters in ICU patterns in the same way
-        $phpOnlyChars = ['i', 'j', 'n', 'g', 'A', 'N', 'L', 'o', 'U', 'u'];
-        foreach ($phpOnlyChars as $char) {
-            if (str_contains($pattern, $char)) {
-                return true;
-            }
-        }
-
-        // Single Y/m/d/H/s without repetition is PHP style
-        // ICU uses yyyy, MM, dd, HH, ss (repeated)
-        if (preg_match('/(?<![a-zA-Z])([YmdHsG])(?![a-zA-Z])/', $pattern)
-            && !preg_match('/(yyyy|MM|dd|HH|mm|ss|EEEE|EEE)/', $pattern)
-        ) {
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/src/Format.php
+++ b/src/Format.php
@@ -400,6 +400,11 @@ class Format
      */
     public static function isPhpDateFormat(string $pattern): bool
     {
+        // ICU locale shortcuts (handled by IcuFormatter, not PHP date())
+        if (in_array($pattern, ['short', 'medium', 'long', 'full'], true)) {
+            return false;
+        }
+
         // These characters are unique to PHP date() and don't appear as single
         // letters in ICU patterns in the same way
         $phpOnlyChars = ['i', 'j', 'n', 'g', 'A', 'N', 'L', 'o', 'U', 'u'];

--- a/src/Formatter/DateTimeFormatter.php
+++ b/src/Formatter/DateTimeFormatter.php
@@ -39,6 +39,11 @@ use Stringable;
  * Note: This formatter ignores the locale parameter as DateTime::format()
  * is not locale-aware. For locale-aware formatting, use IcuFormatter.
  *
+ * PHP date() patterns are NOT auto-detected by Format::parse() because
+ * single-letter PHP format characters (e.g. 'u', 'o') are ambiguous with
+ * ICU patterns and locale shortcuts ('short', 'long', 'full'). Callers
+ * that need PHP date() parsing must use this formatter directly.
+ *
  * @author    Ralf Lang <ralf.lang@ralf-lang.de>
  * @category  Horde
  * @copyright 2026 The Horde Project

--- a/test/Unit/FormatParseTest.php
+++ b/test/Unit/FormatParseTest.php
@@ -51,17 +51,6 @@ class FormatParseTest extends TestCase
         $this->assertSame('22', $dt->format('d'));
     }
 
-    public function testParsePhpDatePattern(): void
-    {
-        $result = Format::parse('2026-05-22', 'Y-m-d');
-
-        $this->assertInstanceOf(DateInterface::class, $result);
-        $dt = $result->toDateTimeImmutable();
-        $this->assertSame('2026', $dt->format('Y'));
-        $this->assertSame('05', $dt->format('m'));
-        $this->assertSame('22', $dt->format('d'));
-    }
-
     public function testParseWithTime24h(): void
     {
         $result = Format::parse('22.05.2026 14:30', 'dd.MM.yyyy HH:mm', 'de_DE');
@@ -168,29 +157,6 @@ class FormatParseTest extends TestCase
         $this->assertSame('30', $dt->format('i'));
     }
 
-    public function testIsPhpDateFormatDetectsPhpPatterns(): void
-    {
-        $this->assertTrue(Format::isPhpDateFormat('Y-m-d'));
-        $this->assertTrue(Format::isPhpDateFormat('Y-m-d H:i:s'));
-        $this->assertTrue(Format::isPhpDateFormat('d/m/Y'));
-        $this->assertTrue(Format::isPhpDateFormat('j.n.Y'));
-    }
-
-    public function testIsPhpDateFormatRejectsIcuPatterns(): void
-    {
-        $this->assertFalse(Format::isPhpDateFormat('dd.MM.yyyy'));
-        $this->assertFalse(Format::isPhpDateFormat('yyyy-MM-dd HH:mm:ss'));
-        $this->assertFalse(Format::isPhpDateFormat('EEEE, MMMM dd'));
-    }
-
-    public function testIsPhpDateFormatRejectsIcuShortcuts(): void
-    {
-        $this->assertFalse(Format::isPhpDateFormat('short'));
-        $this->assertFalse(Format::isPhpDateFormat('medium'));
-        $this->assertFalse(Format::isPhpDateFormat('long'));
-        $this->assertFalse(Format::isPhpDateFormat('full'));
-    }
-
     public function testParseIcuShortcutPattern(): void
     {
         $result = Format::parse('29.05.26', 'short', 'de_DE');
@@ -200,14 +166,5 @@ class FormatParseTest extends TestCase
         $this->assertSame('2026', $dt->format('Y'));
         $this->assertSame('05', $dt->format('m'));
         $this->assertSame('29', $dt->format('d'));
-    }
-
-    public function testIsPhpDateFormatRejectsStrftime(): void
-    {
-        // isPhpDateFormat is only called after isStrftimeFormat returns false,
-        // so it doesn't need to handle strftime patterns. But patterns without
-        // a % are already not strftime — verify ICU-like patterns are rejected.
-        $this->assertFalse(Format::isPhpDateFormat('dd.MM.yyyy'));
-        $this->assertFalse(Format::isPhpDateFormat('EEEE, MMMM dd'));
     }
 }

--- a/test/Unit/FormatParseTest.php
+++ b/test/Unit/FormatParseTest.php
@@ -183,6 +183,25 @@ class FormatParseTest extends TestCase
         $this->assertFalse(Format::isPhpDateFormat('EEEE, MMMM dd'));
     }
 
+    public function testIsPhpDateFormatRejectsIcuShortcuts(): void
+    {
+        $this->assertFalse(Format::isPhpDateFormat('short'));
+        $this->assertFalse(Format::isPhpDateFormat('medium'));
+        $this->assertFalse(Format::isPhpDateFormat('long'));
+        $this->assertFalse(Format::isPhpDateFormat('full'));
+    }
+
+    public function testParseIcuShortcutPattern(): void
+    {
+        $result = Format::parse('29.05.26', 'short', 'de_DE');
+
+        $this->assertInstanceOf(DateInterface::class, $result);
+        $dt = $result->toDateTimeImmutable();
+        $this->assertSame('2026', $dt->format('Y'));
+        $this->assertSame('05', $dt->format('m'));
+        $this->assertSame('29', $dt->format('d'));
+    }
+
     public function testIsPhpDateFormatRejectsStrftime(): void
     {
         // isPhpDateFormat is only called after isStrftimeFormat returns false,


### PR DESCRIPTION
### Summary
Format::isPhpDateFormat() used str_contains() on PHP-specific format letters, so ICU locale shortcuts were misclassified as PHP date() syntax:

short and long match o (ISO week-year)
full matches u (microseconds)
Format::parse() then routed those patterns to DateTimeFormatter instead of IcuFormatter. Parsing failed for common prefs such as date_format_mini = short (e.g. 29.05.26 with pattern short), which broke consumers like horde/nag after #14.

Exclude ICU shortcuts short, medium, long, and full in isPhpDateFormat() before the character scan, consistent with IcuFormatter and Format::formatDate().

### Changes
Format::isPhpDateFormat(): return false for ICU shortcuts
FormatParseTest: tests for shortcut rejection and Format::parse('29.05.26', 'short', 'de_DE')
Test plan

 vendor/bin/phpunit test/Unit/FormatParseTest.php

 Format::parse('29.05.26', 'short', 'de_DE') returns 2026-05-29

 Format::isPhpDateFormat('short') is false; Format::isPhpDateFormat('Y-m-d') remains true

 nag: save task due date with mini date format set to Short (no DateTimeFormatter parse error)
Fixes regression introduced by #14. Related: horde/nag (uses Format::parse() / Format::parseDateTime() for parseDate()).