### PR TITLE
feat(format): add TIME_ONLY constant and  parameter to formatDate()

### DIFF
--- a/src/Format.php
+++ b/src/Format.php
@@ -41,6 +41,11 @@ use Stringable;
 class Format
 {
     /**
+     * Constant for the $timeOnly parameter of formatDate().
+     */
+     public const TIME_ONLY = true;
+
+    /**
      * Mapping of strftime specifiers to ICU patterns
      */
     protected static array $strftimeToIcuMap = [
@@ -229,7 +234,8 @@ class Format
     public static function formatDate(
         int|string|DateTime|DateTimeInterface $timestamp,
         string $format,
-        string $locale = 'en_US'
+        string $locale = 'en_US',
+        bool $timeOnly = false
     ): string {
         if ($timestamp instanceof DateTime || $timestamp instanceof DateTimeInterface) {
             $timestamp = $timestamp->getTimestamp();
@@ -262,8 +268,8 @@ class Format
             };
             $formatter = IntlDateFormatter::create(
                 $locale,
-                $dateStyle,
-                IntlDateFormatter::NONE
+                $timeOnly ? IntlDateFormatter::NONE : $dateStyle,
+                $timeOnly ? $dateStyle : IntlDateFormatter::NONE
             );
         } else {
             $formatter = IntlDateFormatter::create(


### PR DESCRIPTION
Format::formatDate() accepted named ICU styles ('short', 'medium', 'long', 'full') but always formatted the date portion only, passing IntlDateFormatter::NONE for the time portion.
This adds a $timeOnly parameter (default false, fully backward compatible) and a TIME_ONLY constant, allowing callers to format the time portion only using the same named ICU styles:
```
phpFormat::formatDate(time(), 'medium', 'fr_FR', Format::TIME_ONLY); // 21:09:24
Format::formatDate(time(), 'short',  'fr_FR', Format::TIME_ONLY); // 21:09
```
When $timeOnly is false (default), behaviour is identical to before.
This is a prerequisite for:

horde/base fix(prefs): restore locale-aware time format defaults via ICU styles
horde/imp fix(message): use locale-aware time formatting in IMP_Message_Date (#22)